### PR TITLE
Add root to args of path.resolve

### DIFF
--- a/src/Jsoner.js
+++ b/src/Jsoner.js
@@ -15,7 +15,7 @@ class Jsoner {
   _mkdirIfNecessary() {
     this.outputPath.split('/').forEach((dir, index, splits) => {
       const parent = splits.slice(0, index).join('/');
-      const dirPath = path.resolve(parent, dir);
+      const dirPath = path.resolve('/', parent, dir);
       if (!fs.existsSync(dirPath)) {
         fs.mkdirSync(dirPath);
       }

--- a/src/Task.js
+++ b/src/Task.js
@@ -40,6 +40,8 @@ class Task {
       body: body
     };
 
+    t.options = {};
+
     return t;
   }
 
@@ -61,6 +63,9 @@ class Task {
       },
       body: response.data
     };
+
+    t.options = {};
+
     return t;
 
   }


### PR DESCRIPTION
The original code creates an unexpected folder in application root directory, "User" folder when using Mac and "root" folder when using CentOS. To fix this, I added root('/') to the args of path.resolve. I've already confirmed it works on both Mac and CentOS.